### PR TITLE
Use .text() for CVE ID in modal title (defense-in-depth)

### DIFF
--- a/cveInterface.js
+++ b/cveInterface.js
@@ -854,7 +854,7 @@ function deepdive(_, _, row, el) {
 	}
 	$('#updaterecord').html("Update User");
     } else if(("cve_id" in row) && ("state" in row)) {
-	$('#cveUpdateModal .mtitle').html("("+row.cve_id+")");	
+	$('#cveUpdateModal .mtitle').text("("+row.cve_id+")");	
 	if (row.state == "RESERVED") {
 	    $('#updaterecord').html("Edit & Publish CVE").show();
 	    $('#cveUpdateModal .cveupdate').html("Publish CVE");


### PR DESCRIPTION
## Summary

Hi Vijay! Great work on the XSS fixes in the recent 1.0.24 update — you caught all the major ones.

This is a small follow-up that switches one remaining `.html()` call to `.text()` for the CVE ID displayed in the modal title (`deepdive()` at line 857). CVE IDs are format-constrained so the risk is very low, but this keeps things consistent with the `.text()` pattern you established in your fix.

- `$('#cveUpdateModal .mtitle').html(...)` → `.text(...)`

## Test plan

- [ ] Open any CVE record from the table — modal title should still display the CVE ID correctly
- [ ] Verify no HTML rendering issues in the modal title


🤖 Generated with [Claude Code](https://claude.com/claude-code)