### PR TITLE
Harden API key storage and encryption key management

### DIFF
--- a/cveInterface.js
+++ b/cveInterface.js
@@ -1,5 +1,5 @@
 /* Clientlib, UI html, css and UI js all are version controlled */
-const _version = "1.0.24";
+const _version = "1.0.25";
 const _tool = "CVE Services Client Interface "+_version;
 const _cna_template = { "descriptions": [ { "lang": "${descriptions.0.lang}", "value": "${descriptions.0.value}"} ] ,  "affected": [ { "versions": [{"version": "${affected.0.versions.0.version}"}], "product": "${affected.0.product}", "vendor": "${affected.0.vendor|client.orgobj.name}" } ],"references": [ { "name": "${references.0.name}", "url": "${references.0.url}" }], "providerMetadata": { "orgId": "${client.userobj.org_UUID}", "shortName": "${client.org}" } }
 const schemaUrl = "https://cveproject.github.io/cve-schema/schema/docs/CVE_Record_Format_bundled.json";

--- a/cveInterface.js
+++ b/cveInterface.js
@@ -628,6 +628,9 @@ async function login() {
 	    store = sessionStorage;
 	}
 	$('#loginModal .form-control').each(function(_,x) {
+	    /* Skip storing API key in plaintext; enable_encryption()
+	       will store it after encryption completes */
+	    if($(x).attr('id') === 'key') return;
 	    store.setItem(store_tag+$(x).attr('id'),$(x).val());
 	});
     } else {
@@ -1883,6 +1886,10 @@ function enable_encryption() {
 		top_alert("warning","Encrypting API key failed, see console log for errors");
 	    };
 	}
+    }).fail(function() {
+	/* If encryption script fails to load, store key in session only */
+	sessionStorage.setItem(store_tag+"key",client.key);
+	top_alert("warning","Encryption unavailable. API key stored in session only.");
     });
 }
 async function showorg() {

--- a/encrypt-storage.js
+++ b/encrypt-storage.js
@@ -98,14 +98,19 @@ function dbManager(user,key,sum) {
 async function save_key(user,key) {
     let fpb = await window.crypto.subtle.exportKey("jwk", key.publicKey);
     let fpr = await window.crypto.subtle.exportKey("jwk", key.privateKey);
-    let exportKey = {epr: fpr, epb: fpb};
+    /* Re-import private key as non-extractable to prevent JWK extraction */
+    let safePrivateKey = await window.crypto.subtle.importKey("jwk",fpr,
+	{name:"RSA-OAEP", hash: {name: "SHA-256"}},false,["decrypt"]);
+    let exportKey = {epr: safePrivateKey, epb: fpb};
     let sum = {sha256: await sha256sum(fpb.n)};
     dbManager(user,exportKey,sum);
     return exportKey;
 }
 async function import_key({epr,epb}) {
-    let prkey = await window.crypto.subtle.importKey("jwk",epr,{name:"RSA-OAEP", hash: {name: "SHA-256"}},false,['decrypt']);
-    let pbkey = await window.crypto.subtle.importKey("jwk",epb,{name:"RSA-OAEP", hash: {name: "SHA-256"}},false,['encrypt']);
+    /* epr may be a CryptoKey (new) or JWK object (legacy) */
+    let prkey = (epr instanceof CryptoKey) ? epr :
+	await window.crypto.subtle.importKey("jwk",epr,{name:"RSA-OAEP", hash: {name: "SHA-256"}},false,["decrypt"]);
+    let pbkey = await window.crypto.subtle.importKey("jwk",epb,{name:"RSA-OAEP", hash: {name: "SHA-256"}},false,["encrypt"]);
     return { privateKey: prkey, publicKey: pbkey  };
 }
 

--- a/encrypt-storage.js
+++ b/encrypt-storage.js
@@ -1,5 +1,5 @@
 /* Encryption API using JavaScript native crypto.js and indexeDB for storing private keys */
-const encrypt_storage_version = "1.1.14";
+const encrypt_storage_version = "1.1.15";
 async function encryptMessage(message,publicKey) {
     let encoded = new TextEncoder().encode(message);
     let ciphertext = await window.crypto.subtle.encrypt(


### PR DESCRIPTION
## Summary

Hey Vijay! Following up on the security items from our email thread — this PR addresses the credential storage and encryption concerns (Findings 2 and 3 from my report).

Three changes:

1. **Don't store the API key in plaintext during login.** Previously the key was written to localStorage/sessionStorage immediately at login, before `enable_encryption()` finished its async work. Now the `key` field is skipped during the initial form storage loop — `enable_encryption()` already handles storing the encrypted version once it's ready.

2. **Store RSA private key as non-extractable CryptoKey.** In `save_key()`, the private key is now re-imported with `extractable: false` before being stored in IndexedDB. This means even if script accesses IndexedDB, it can't export the private key as JWK. Backward compatible — `import_key()` handles both legacy JWK entries and new CryptoKey entries gracefully.

3. **Add error handling for encryption script load failure.** If `encrypt-storage.js` fails to load (network issue, CSP, etc.), a `.fail()` handler now stores the key in `sessionStorage` only (not persistent `localStorage`) and warns the user. Previously the plaintext key would silently persist in localStorage forever.

## Test plan

- [ ] Login with "Keep me logged in" checked — verify key is NOT in localStorage immediately after clicking login (check DevTools > Application > Local Storage)
- [ ] After ~2-3 seconds, verify the encrypted key (data URI) appears in localStorage
- [ ] Login without "Keep me logged in" — verify key goes to sessionStorage after encryption
- [ ] If you have existing stored keys from before this change, verify auto-login still works (backward compat)
- [ ] Verify encryption toggle still works from the UI


🤖 Generated with [Claude Code](https://claude.com/claude-code)