### PR TITLE
Make schema references version-agnostic and add version detection

### DIFF
--- a/cveInterface.js
+++ b/cveInterface.js
@@ -19,7 +19,7 @@ function askchatGPT(CVE_JSON) {
     if(!CVE_JSON)
 	CVE_JSON = ace.edit('mjsoneditor').getValue();
     if(check_json(JSON.parse(CVE_JSON))) {
-	const prompt = "I have this CVE record and want help improve it especially the \"affected\" block.\nPlease check it against the CVE JSON 5.0 schema guidance (https://github.com/CVEProject/cve-schema/blob/main/schema/docs/versions.md).\nHere is the full CVE Record:\n\n " + CVE_JSON;
+	const prompt = "I have this CVE record and want help improve it especially the \"affected\" block.\nPlease check it against the CVE JSON schema guidance (https://github.com/CVEProject/cve-schema/blob/main/schema/docs/versions.md).\nHere is the full CVE Record:\n\n " + CVE_JSON;
 	const url = "https://chat.openai.com/?prompt=" + encodeURIComponent(prompt);
 	window.open(url, "_blank");
     } else {
@@ -1968,7 +1968,7 @@ function queryParser(query) {
     return urlParams
 }
 function allFields(newTab,oldTab) {
-    top_alert("warning","All Fields is experimental and useful in seeing the full CVE5.0 JSON schema representation!",8000);
+    top_alert("warning","All Fields is experimental and useful in seeing the full CVE JSON schema representation!",8000);
     let cveData = {};
     const href = oldTab.getAttribute('href');
     if(href == "#nice") {

--- a/schemaToForm.js
+++ b/schemaToForm.js
@@ -497,6 +497,7 @@ function schemaToForm(schemaUrl, elementId) {
 	const dElement = document.getElementById(elementId);
 	if (schema && dElement) {
 	    main.dElement = dElement;
+	    main.schemaVersion = schema.title || schema["$id"] || "unknown";
             createFormFromSchema(schema, dElement);
 	} else {
             document.getElementById(elementId).textContent = 'Failed to load schema.';


### PR DESCRIPTION
## Summary

Hi Vijay! Small prep work for the eventual CVE JSON 5.1 migration:

- Removed hardcoded "CVE 5.0" from the ChatGPT prompt and the All Fields tab alert — now says "CVE JSON schema" generically. This way the UI stays accurate as the upstream schema evolves.

- Added `main.schemaVersion` detection in `schemaToForm.js` — when the schema is fetched, its `title` or `$id` is captured. This gives downstream code a way to know which schema version was loaded, which will be useful for conditional field handling when 5.1 lands.

## Test plan

- [ ] Open the All Fields tab — verify alert says "CVE JSON schema representation" (not "CVE5.0")
- [ ] Click the ChatGPT button with a CVE loaded — verify the prompt references "CVE JSON schema guidance"
- [ ] All Fields form still renders correctly from the fetched schema


🤖 Generated with [Claude Code](https://claude.com/claude-code)