### PR TITLE
Remove unsupported ADP API routes (GET, DELETE)

### DIFF
--- a/cveClientlib.js
+++ b/cveClientlib.js
@@ -12,16 +12,6 @@ class cveClient {
 	let opts = {method: "PUT"};
 	return this.putjson(path,opts,null,adp);
     }
-    getadp(cve) {
-	return this.getjson("/cve/" + cve + "/adp");
-    }
-    deleteadp(cve) {
-	let path = "/cve/" + cve + "/adp";
-	let opts = {method: "DELETE"};
-	return this.rfetch(path, opts).then(function(r) {
-	    return r.json();
-	});
-    }
     publishcve(cve,cnajson,update,rejected) {
 	/* Create or Update a CVE */
 	let opts = null;

--- a/cveClientlib.js
+++ b/cveClientlib.js
@@ -7,6 +7,8 @@ class cveClient {
 	this.user_path = "/org/" + this.org + "/user/" + this.user;
 	this._version = "1.0.15";
     }
+    /* PUT /cve/{id}/adp — the only ADP endpoint per CVE Services API spec
+       See https://cveawg.mitre.org/api-docs/ */
     publishadp(cve,adp) {
 	let path = "/cve/" + cve + "/adp";
 	let opts = {method: "PUT"};

--- a/cveInterface.js
+++ b/cveInterface.js
@@ -1645,33 +1645,6 @@ async function publish_adp() {
         swal_error("Could not publish this ADP data. Fix the errors please!");
     }
 }
-async function delete_adp() {
-    let mr = JSON.parse($("#deepDive").attr("data-crecord"));
-    let cve_id = mr.cve_id;
-    Swal.fire({
-	title: "Delete ADP data for " + cve_id + "?",
-	text: "This will remove your ADP container from this CVE.",
-	icon: "warning",
-	showDenyButton: true,
-	confirmButtonText: "Delete",
-	denyButtonText: "Cancel"
-    }).then(async function(result) {
-	if(result.isConfirmed) {
-	    let d = await client.deleteadp(cve_id);
-	    if("error" in d) {
-		swal_error("Failed to delete ADP data: " + d.error);
-		return;
-	    }
-	    Swal.fire({
-		title: "ADP data deleted!",
-		text: d.message || "ADP container removed.",
-		icon: "success",
-		timer: 1800
-	    });
-	    $("#cveUpdateModal").modal("hide");
-	}
-    });
-}
 function add_validators(pubcve) {
     let validStatus = {"affected": true, "unknown": true };
     if('affected' in pubcve)

--- a/cveInterface.js
+++ b/cveInterface.js
@@ -1623,8 +1623,8 @@ async function publish_adp() {
 	}
 	let d = await client.publishadp(cve_id,adp) 
 	if("error" in d) {
-            swal_error("Failed to publish CVE, Error : "+d.error);
-            //console.log(d);
+            swal_error("Failed to publish ADP, Error : "+d.error);
+            console.log(d);
             return;
 	}
 	if(("created" in d) || ("updated" in d)) {
@@ -1636,7 +1636,7 @@ async function publish_adp() {
             });
 	    $('#cveUpdateModal').modal('hide');	    
 	} else {
-            //console.log(d);
+            console.log(d);
             swal_error("Unknown error CVE could not be updated. See console "+
                        " log for details!");
 	}

--- a/index.html
+++ b/index.html
@@ -521,9 +521,6 @@
 	    <a href="javascript:void(0)" class="btn btn-primary adpupdate d-none"
 	       onclick="publish_adp()">
 	      Publish ADP</a>
-	    <a href="javascript:void(0)" class="btn btn-danger adpupdate d-none"
-	       onclick="delete_adp()">
-	      Delete ADP</a>
 	  </div>
 	</div>
       </div>


### PR DESCRIPTION
Sorry about this one! I added GET and DELETE ADP routes in PR #43 without checking the API spec first — rookie mistake. Thanks to @zmanion for [catching it](https://github.com/CERTCC/cveClient/pull/43#issuecomment-4172709702) from their SADP pilot work.

## Summary

- Remove `getadp()` and `deleteadp()` methods from `cveClientlib.js`
- Remove `delete_adp()` UI function from `cveInterface.js`
- Remove "Delete ADP" button from `index.html`
- Add API spec reference comment on `publishadp()` so this doesn't happen again
- Fix copy-paste error in ADP error message ("Failed to publish CVE" → "Failed to publish ADP")
- Enable `console.log` for ADP errors (was commented out, hiding failures)

The [CVE Services API spec](https://cveawg.mitre.org/api-docs/) only defines **PUT** `/cve/{id}/adp` for ADP containers — there are no GET or DELETE endpoints. `publishadp()` (PUT) is unchanged since it maps to the one supported ADP route.

## Test plan

- [ ] Open a PUBLISHED CVE — verify "Publish ADP" button still appears on ADP tab
- [ ] Verify "Delete ADP" button is no longer shown
- [ ] Confirm ADP publish workflow still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)