### PR TITLE
ci: update GitHub Actions to v6 for Node.js 24 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         node-version: [22, 24]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm


### PR DESCRIPTION
## Summary
- Update `actions/checkout` from v4 to v6
- Update `actions/setup-node` from v4 to v6

The v4 actions run on Node.js 20, which GitHub is deprecating. Node.js 20 will be forced off Actions runners on June 2, 2026 and removed entirely on September 16, 2026. v6 runs on Node.js 24.

## Test plan
- [ ] CI passes on this PR without the Node.js 20 deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)